### PR TITLE
Fix customize navigation color

### DIFF
--- a/src/ProgressSteps/ProgressSteps.tsx
+++ b/src/ProgressSteps/ProgressSteps.tsx
@@ -9,6 +9,20 @@ interface ProgressStepsProps {
   topOffset?: number;
   marginBottom?: number;
   children: ReactElement[];
+  activeStepIconBorderColor?: string;
+  activeLabelColor?: string;
+  activeStepNumColor?: string;
+  activeStepIconColor?: string;
+  completedStepIconColor?: string;
+  completedProgressBarColor?: string;
+  completedCheckColor?: string;
+  progressBarColor?: string;
+  disabledStepIconColor?: string;
+  labelFontFamily?: string;
+  labelColor?: string;
+  completedLabelColor?: string;
+  completedStepNumColor?: string;
+  disabledStepNumColor?: string;
 }
 
 const ProgressSteps: React.FC<ProgressStepsProps> = ({
@@ -17,6 +31,20 @@ const ProgressSteps: React.FC<ProgressStepsProps> = ({
   topOffset = 30,
   marginBottom = 50,
   children,
+  activeStepIconBorderColor = undefined,
+  activeLabelColor = undefined,
+  activeStepNumColor = undefined,
+  activeStepIconColor = undefined,
+  completedStepIconColor = undefined,
+  completedProgressBarColor = undefined,
+  completedCheckColor = undefined,
+  progressBarColor = undefined,
+  disabledStepIconColor = undefined,
+  labelFontFamily = undefined,
+  labelColor = undefined,
+  completedLabelColor = undefined,
+  completedStepNumColor = undefined,
+  disabledStepNumColor = undefined,
 }) => {
   const [stepCount, setStepCount] = useState(0);
   const [currentStep, setCurrentStep] = useState(activeStep);
@@ -43,6 +71,20 @@ const ProgressSteps: React.FC<ProgressStepsProps> = ({
             isLastStep={i === stepCount - 1}
             isCompletedStep={isCompletedStep}
             isActiveStep={isActiveStep}
+            activeStepIconBorderColor={activeStepIconBorderColor}
+            activeLabelColor={activeLabelColor}
+            activeStepNumColor={activeStepNumColor}
+            activeStepIconColor={activeStepIconColor}
+            completedStepIconColor={completedStepIconColor}
+            completedProgressBarColor={completedProgressBarColor}
+            completedCheckColor={completedCheckColor}
+            progressBarColor={progressBarColor}
+            disabledStepIconColor={disabledStepIconColor}
+            labelFontFamily={labelFontFamily}
+            labelColor={labelColor}
+            completedLabelColor={completedLabelColor}
+            completedStepNumColor={completedStepNumColor}
+            disabledStepNumColor={disabledStepNumColor}
           />
         </View>
       );

--- a/src/ProgressSteps/ProgressSteps.tsx
+++ b/src/ProgressSteps/ProgressSteps.tsx
@@ -18,7 +18,6 @@ interface ProgressStepsProps {
   completedCheckColor?: string;
   progressBarColor?: string;
   disabledStepIconColor?: string;
-  labelFontFamily?: string;
   labelColor?: string;
   completedLabelColor?: string;
   completedStepNumColor?: string;
@@ -40,7 +39,6 @@ const ProgressSteps: React.FC<ProgressStepsProps> = ({
   completedCheckColor = undefined,
   progressBarColor = undefined,
   disabledStepIconColor = undefined,
-  labelFontFamily = undefined,
   labelColor = undefined,
   completedLabelColor = undefined,
   completedStepNumColor = undefined,
@@ -80,7 +78,6 @@ const ProgressSteps: React.FC<ProgressStepsProps> = ({
             completedCheckColor={completedCheckColor}
             progressBarColor={progressBarColor}
             disabledStepIconColor={disabledStepIconColor}
-            labelFontFamily={labelFontFamily}
             labelColor={labelColor}
             completedLabelColor={completedLabelColor}
             completedStepNumColor={completedStepNumColor}


### PR DESCRIPTION
It's not possible to change color of navigation items. See https://github.com/ofernand21/react-native-progress-stepper/issues/2.

The reason of that behavior is, that arguments from ProgressSteps component are not passing to StepIcon component.
Please check it.